### PR TITLE
Support forcing values to uInt64 and Int64

### DIFF
--- a/moshipack/src/main/kotlin/com/daveanthonythomas/moshipack/MoshiPack.kt
+++ b/moshipack/src/main/kotlin/com/daveanthonythomas/moshipack/MoshiPack.kt
@@ -17,8 +17,8 @@ class MoshiPack(private var builder: Moshi.Builder.() -> kotlin.Unit = {},
     }
 
     companion object {
-        inline fun <reified T> pack(value: T, moshi: Moshi): BufferedSource =
-                Buffer().also { moshi.adapter<T>(T::class.java).toJson(MsgpackWriter(it), value) }
+        inline fun <reified T> pack(value: T, moshi: Moshi, format: Byte? = null): BufferedSource =
+                Buffer().also { moshi.adapter<T>(T::class.java).toJson(MsgpackWriter(it, format), value) }
 
         inline fun <reified T> pack(value: T, crossinline builder: Moshi.Builder.() -> Unit = {}): BufferedSource =
                 pack(value, moshi(builder))
@@ -49,8 +49,8 @@ class MoshiPack(private var builder: Moshi.Builder.() -> kotlin.Unit = {},
                 .transform(source)
     }
 
-    inline fun <reified T> pack(value: T) = MoshiPack.pack(value, moshi)
-    inline fun <reified T> packToByteArray(value: T): ByteArray = pack(value).readByteArray()
+    inline fun <reified T> pack(value: T, format: Byte? = null) = MoshiPack.pack(value, moshi, format)
+    inline fun <reified T> packToByteArray(value: T, format: Byte? = null): ByteArray = pack(value, format).readByteArray()
     inline fun <reified T> unpack(bytes: ByteArray): T = unpack(Buffer().apply { write(bytes) })
     inline fun <reified T> unpack(source: BufferedSource): T = MoshiPack.unpack(source, moshi)
 

--- a/moshipack/src/main/kotlin/com/squareup/moshi/MsgpackWriter.kt
+++ b/moshipack/src/main/kotlin/com/squareup/moshi/MsgpackWriter.kt
@@ -77,17 +77,28 @@ class MsgpackWriter(private val sink: BufferedSink, private val forcedOutputType
         }
         writeDeferredName()
         beforeValue()
-        println("value for non null long {$value}")
-        if (forcedOutputType != null && forcedOutputType != MsgpackFormat.UINT_64) {
-            throw RuntimeException("Target format not supported")
-        } else if (forcedOutputType == MsgpackFormat.UINT_64) {
-            currentBuffer.writeByte(MsgpackFormat.UINT_64.toInt())
-            currentBuffer.writeLong(value)
-        } else {
+        if (forcedOutputType == null) {
             getSmallestType(value)
+        } else {
+            getForcedType(value)
         }
+
         pathIndices[stackSize - 1]++
         return this
+    }
+
+    private fun getForcedType(value: Long) {
+        when (forcedOutputType) {
+            MsgpackFormat.UINT_64 -> {
+                currentBuffer.writeByte(MsgpackFormat.UINT_64.toInt())
+                currentBuffer.writeLong(value)
+            }
+            MsgpackFormat.INT_64 -> {
+                currentBuffer.writeByte(MsgpackFormat.INT_64.toInt())
+                currentBuffer.writeLong(value)
+            }
+            else -> throw RuntimeException("Target format not supported")
+        }
     }
 
     private fun getSmallestType(value: Long) {

--- a/moshipack/src/main/kotlin/com/squareup/moshi/MsgpackWriter.kt
+++ b/moshipack/src/main/kotlin/com/squareup/moshi/MsgpackWriter.kt
@@ -1,6 +1,5 @@
 package com.squareup.moshi
 
-import okio.BufferedSink
 import com.squareup.moshi.JsonScope.DANGLING_NAME
 import com.squareup.moshi.JsonScope.EMPTY_ARRAY
 import com.squareup.moshi.JsonScope.EMPTY_DOCUMENT
@@ -8,10 +7,11 @@ import com.squareup.moshi.JsonScope.EMPTY_OBJECT
 import com.squareup.moshi.JsonScope.NONEMPTY_ARRAY
 import com.squareup.moshi.JsonScope.NONEMPTY_DOCUMENT
 import com.squareup.moshi.JsonScope.NONEMPTY_OBJECT
-import java.io.IOException
 import okio.Buffer
+import okio.BufferedSink
+import java.io.IOException
 
-class MsgpackWriter(private val sink: BufferedSink) : JsonWriter() {
+class MsgpackWriter(private val sink: BufferedSink, private val forcedOutputType: Byte? = null) : JsonWriter() {
 
     private var deferredName: String? = null
     private val pathBuffers = Array<Buffer?>(32) { null }
@@ -19,7 +19,7 @@ class MsgpackWriter(private val sink: BufferedSink) : JsonWriter() {
     private val currentIndex get() = stackSize - 1
     private val currentBuffer
         get() = if (currentIndex == 0) sink else pathBuffers[currentIndex]
-                    ?: throw IllegalStateException("Path buffer not initialized.")
+            ?: throw IllegalStateException("Path buffer not initialized.")
 
     init {
         pushScope(EMPTY_DOCUMENT)
@@ -77,6 +77,20 @@ class MsgpackWriter(private val sink: BufferedSink) : JsonWriter() {
         }
         writeDeferredName()
         beforeValue()
+        println("value for non null long {$value}")
+        if (forcedOutputType != null && forcedOutputType != MsgpackFormat.UINT_64) {
+            throw RuntimeException("Target format not supported")
+        } else if (forcedOutputType == MsgpackFormat.UINT_64) {
+            currentBuffer.writeByte(MsgpackFormat.UINT_64.toInt())
+            currentBuffer.writeLong(value)
+        } else {
+            getSmallestType(value)
+        }
+        pathIndices[stackSize - 1]++
+        return this
+    }
+
+    private fun getSmallestType(value: Long) {
         when (value) {
             in MsgpackFormat.FIX_INT_MIN..MsgpackFormat.FIX_INT_MAX -> {
                 currentBuffer.writeByte(value.toInt())
@@ -110,8 +124,6 @@ class MsgpackWriter(private val sink: BufferedSink) : JsonWriter() {
                 currentBuffer.writeLong(value)
             }
         }
-        pathIndices[stackSize - 1]++
-        return this
     }
 
     override fun value(value: Number?): JsonWriter {

--- a/moshipack/src/test/kotlin/TestMessagePackWriter.kt
+++ b/moshipack/src/test/kotlin/TestMessagePackWriter.kt
@@ -205,4 +205,60 @@ class TestMessagePackWriter {
         )
         assertArrayEquals(expected, bytes)
     }
+
+
+    @Test
+    fun fixedInt64WorksWithZero() {
+        // Single Int64 value
+        val expected = byteArrayOf(
+            0xd3.toByte(), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        )
+        val bytes =
+            MoshiPack(moshi = Moshi.Builder().build()).packToByteArray(0x00, MsgpackFormat.INT_64)
+        assertArrayEquals(expected, bytes)
+    }
+
+    @Test
+    fun fixedInt64WorksWithMaxLong() {
+        // uInt64 format byte followed by Long.MAX_VALUE in bytes
+        val expected = byteArrayOf(
+            0xd3.toByte(),
+            0x7F, 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(),
+            0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()
+        )
+        val bytes = MoshiPack(moshi = Moshi.Builder().build()).packToByteArray(
+            Long.MAX_VALUE,
+            MsgpackFormat.INT_64
+        )
+        assertArrayEquals(expected, bytes)
+    }
+
+    @Test
+    fun fixedInt64WorksWithMaxInt() {
+        // Int64 format byte value followed by value Int.MAX_VALUE in bytes
+        val expected = byteArrayOf(
+            0xd3.toByte(),
+            0x00, 0x00, 0x00, 0x00, 0x7F, 0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte()
+        )
+        val bytes = MoshiPack(moshi = Moshi.Builder().build()).packToByteArray(
+            Int.MAX_VALUE,
+            MsgpackFormat.INT_64
+        )
+        assertArrayEquals(expected, bytes)
+    }
+
+    @Test
+    fun fixedInt64WorksWithSingleElementArray() {
+        // fixarray format byte, Int64 format byte, zero value bytes
+        val expected = byteArrayOf(
+            0x91.toByte(),
+            0xd3.toByte(), 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+        )
+        val bytes = MoshiPack(moshi = Moshi.Builder().build()).packToByteArray(
+            byteArrayOf(0x00),
+            MsgpackFormat.INT_64
+        )
+        assertArrayEquals(expected, bytes)
+    }
 }


### PR DESCRIPTION
I'm working with a device which sends and receives data using msgPack. However, for certain commands it expects the data to be encoded using uInt64 or a Int64 value regardless of whether a smaller type can be used.